### PR TITLE
Update License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 PADCI
+Copyright © 2018 PADCDI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Spelling:
 - changed PADCI to PACDCI
 - changed copyright symbol from (c) to ©